### PR TITLE
feat: use custom rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "browserslist": "4.24.2",
     "commander": "12.1.0",
     "custom-element-vs-code-integration": "1.4.1",
+    "defu": "6.1.4",
     "glob": "11.0.0",
     "lightningcss": "1.28.1",
     "minify-html-literals": "1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       custom-element-vs-code-integration:
         specifier: 1.4.1
         version: 1.4.1(prettier@2.8.8)
+      defu:
+        specifier: 6.1.4
+        version: 6.1.4
       glob:
         specifier: 11.0.0
         version: 11.0.0
@@ -567,6 +570,9 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   del@5.1.0:
     resolution: {integrity: sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==}
@@ -1969,6 +1975,8 @@ snapshots:
       ms: 2.1.2
 
   deepmerge@4.3.1: {}
+
+  defu@6.1.4: {}
 
   del@5.1.0:
     dependencies:

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -24,6 +24,7 @@ export async function getUserConfig() {
     entryPoints: ['./src/**/index.ts'],
     tsconfig: './tsconfig.lib.json',
     sourcemap: false,
-    ...userConfig.default?.library
+    ...userConfig.default?.library,
+    rollupOptions: userConfig.default?.rollupOptions || {},
   };
 }


### PR DESCRIPTION
Allow users to override the default configuration of blueprints, for instance, to add new plugins.

```js
// blueprint.config.js
import postcss from "rollup-plugin-postcss";
import postcssLit from 'rollup-plugin-postcss-lit';

export default {
  library: {
    entryPoints: ['./src/**/index.ts', './src/include/*.ts'],
    externals: [/^tslib/, /^lit/, /^@blueprintui/]
  },
  rollupOptions: {
    plugins: [
      postcss({
        inject: false,
      }),
      postcssLit(),
    ]
  }
};
```