### PR TITLE
fix: address high and medium code quality issues across CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .rollup.cache
 .firebase
 dist
+.DS_Store

--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintui/cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "main": "./src/index.mjs",
   "bin": {

--- a/projects/cli/src/custom-elements-manifest.config.mjs
+++ b/projects/cli/src/custom-elements-manifest.config.mjs
@@ -1,19 +1,10 @@
 import { resolve } from 'path';
 import { customElementVsCodePlugin } from 'custom-element-vs-code-integration';
+import { getUserConfig } from './utils.mjs';
 
 const cwd = process.cwd();
-const baseSrc = resolve(cwd, 'src');
-
-let userConfig = {};
-if (process.env.BLUEPRINTUI_CONFIG) {
-  userConfig = await import(process.env.BLUEPRINTUI_CONFIG);
-}
-
-const config = {
-  baseDir: './src',
-  outDir: './dist',
-  ...userConfig?.default?.library
-};
+const config = await getUserConfig();
+const baseSrc = resolve(cwd, config.baseDir);
 
 export default {
   globs: [resolve(cwd, config.baseDir)],
@@ -53,8 +44,9 @@ function baseDir() {
   return {
     name: 'base-dir',
     packageLinkPhase({ customElementsManifest }) {
+      const base = baseSrc.endsWith('/') ? baseSrc : `${baseSrc}/`;
       customElementsManifest.modules = JSON.parse(
-        JSON.stringify(customElementsManifest.modules).replaceAll(`"/${baseSrc}`, '"').replaceAll(`"${baseSrc}`, '"')
+        JSON.stringify(customElementsManifest.modules).replaceAll(base, '').replaceAll(base.slice(1), '')
       );
     },
   };

--- a/projects/cli/src/plugin-minify-css.mjs
+++ b/projects/cli/src/plugin-minify-css.mjs
@@ -25,8 +25,9 @@ export const css = (options = {}) => {
           }).code.toString()
         : code;
 
+      const escaped = output.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
       return {
-        code: `const stylesheet = new CSSStyleSheet();stylesheet.replaceSync(\`${output}\`);export default stylesheet;`,
+        code: `const stylesheet = new CSSStyleSheet();stylesheet.replaceSync(\`${escaped}\`);export default stylesheet;`,
         moduleType: 'js',
       };
     },

--- a/projects/cli/src/utils.mjs
+++ b/projects/cli/src/utils.mjs
@@ -1,12 +1,14 @@
 import { cli } from '@custom-elements-manifest/analyzer/cli.js';
 
 export async function runCustomElementsAnalyzer(customElementsManifestConfig) {
-  // disable noisy log output from custom-elements-manifest
+  // disable noisy log output from custom-elements-manifest analyzer
   const log = console.log;
   console.log = () => {};
-  const result = await cli({ argv: ['analyze', '--quiet', '--config', customElementsManifestConfig] });
-  console.log = log;
-  return result;
+  try {
+    return await cli({ argv: ['analyze', '--quiet', '--config', customElementsManifestConfig] });
+  } finally {
+    console.log = log;
+  }
 }
 
 export async function getUserConfig() {


### PR DESCRIPTION
- Exit with non-zero code when `api --test` detects changes (was silently passing in CI)
- Escape backticks and template expressions in CSS plugin output to prevent injection
- Change `--config` from boolean flag to string option accepting a path value
- Remove dead `options.watch` reference in `api` command (copy-paste leftover)
- Replace custom `deepReadDir` with Node 24 built-in `readdir({ recursive: true })`
- Deduplicate config loading in custom-elements-manifest config via `getUserConfig()`
- Fix hardcoded `'src'` baseSrc to use configured `baseDir` value
- Wrap console.log suppression in try/finally to restore on errors
- Remove duplicate watcher event listener that double-closed bundle results
- Clean up path imports removing unused `join`, `lstat` and variable shadowing

https://claude.ai/code/session_0193QoCjBn2mztJWJN5WZbe6